### PR TITLE
Merge Need+Out into a unified Shopping List

### DIFF
--- a/app/blueprints/api.py
+++ b/app/blueprints/api.py
@@ -38,7 +38,7 @@ def list_groceries():
     profile       = _profile()
     status_filter = request.args.get("status", "").strip()
     query         = Grocery.query.filter_by(profile_id=profile)
-    if status_filter in ("Need", "Have", "Out"):
+    if status_filter in ("Need", "Have"):
         query = query.filter_by(status=status_filter)
     items = query.order_by(Grocery.category, Grocery.name).all()
     return jsonify([{
@@ -56,7 +56,7 @@ def create_grocery():
     if not name:
         return jsonify({"error": "name is required"}), 400
     status = data.get("status", "Need")
-    if status not in ("Need", "Have", "Out"):
+    if status not in ("Need", "Have"):
         status = "Need"
     g = Grocery(
         profile_id=profile, name=name,
@@ -84,7 +84,7 @@ def update_grocery(item_id):
         g.unit = data["unit"] or None
     if "category" in data:
         g.category = data["category"] or None
-    if "status" in data and data["status"] in ("Need", "Have", "Out"):
+    if "status" in data and data["status"] in ("Need", "Have"):
         g.status = data["status"]
     db.session.commit()
     return jsonify({"id": g.id, "name": g.name, "status": g.status})

--- a/app/blueprints/groceries.py
+++ b/app/blueprints/groceries.py
@@ -6,22 +6,33 @@ from app.utils.helpers import current_profile, _float
 
 groceries_bp = Blueprint("groceries", __name__)
 
-VALID_STATUSES = ("Need", "Have", "Out")
+VALID_STATUSES = ("Need", "Have")
 
 
 @groceries_bp.route("/")
 def index():
-    """List groceries for the current profile with optional status filter."""
-    profile = current_profile()
-    status_filter = request.args.get("status", "").strip()
+    """Grocery list — defaults to Shopping List (Need items).
+
+    ?status=Need  → Shopping List (default)
+    ?status=Have  → pantry / items on hand
+    ?status=all   → everything
+    """
+    profile       = current_profile()
+    status_filter = request.args.get("status", "Need").strip()
+    show_all      = status_filter.lower() == "all"
 
     query = Grocery.query.filter_by(profile_id=profile)
-    if status_filter in VALID_STATUSES:
+    if not show_all:
+        if status_filter not in VALID_STATUSES:
+            status_filter = "Need"
         query = query.filter_by(status=status_filter)
 
     groceries = query.order_by(Grocery.category, Grocery.name).all()
     return render_template(
-        "groceries/index.html", groceries=groceries, status_filter=status_filter
+        "groceries/index.html",
+        groceries=groceries,
+        status_filter=status_filter,
+        show_all=show_all,
     )
 
 
@@ -49,7 +60,7 @@ def add():
         db.session.add(item)
         try:
             db.session.commit()
-            flash(f"'{item.name}' added.", "success")
+            flash(f"'{item.name}' added to shopping list.", "success")
             return redirect(url_for("groceries.index"))
         except Exception:
             db.session.rollback()
@@ -111,9 +122,39 @@ def delete(item_id):
     return redirect(url_for("groceries.index"))
 
 
-@groceries_bp.route("/bulk-need", methods=["POST"])
-def bulk_need():
-    """Mark all checked grocery items back to 'Need'."""
+@groceries_bp.route("/<int:item_id>/got-it", methods=["POST"])
+def got_it(item_id):
+    """Quick action — mark an item as Have (got it at the store)."""
+    profile = current_profile()
+    item = Grocery.query.filter_by(id=item_id, profile_id=profile).first_or_404()
+    item.status = "Have"
+    try:
+        db.session.commit()
+        flash(f"'{item.name}' marked as Have.", "success")
+    except Exception:
+        db.session.rollback()
+        flash("Something went wrong.", "error")
+    return redirect(request.referrer or url_for("groceries.index"))
+
+
+@groceries_bp.route("/<int:item_id>/out-of-stock", methods=["POST"])
+def out_of_stock(item_id):
+    """Quick action — move a Have item back to the shopping list."""
+    profile = current_profile()
+    item = Grocery.query.filter_by(id=item_id, profile_id=profile).first_or_404()
+    item.status = "Need"
+    try:
+        db.session.commit()
+        flash(f"'{item.name}' added back to shopping list.", "success")
+    except Exception:
+        db.session.rollback()
+        flash("Something went wrong.", "error")
+    return redirect(request.referrer or url_for("groceries.index"))
+
+
+@groceries_bp.route("/bulk-have", methods=["POST"])
+def bulk_have():
+    """Mark all checked shopping list items as Have (bulk checkout)."""
     profile = current_profile()
     raw_ids = request.form.getlist("item_ids")
     ids = [int(i) for i in raw_ids if i.isdigit()]
@@ -121,10 +162,10 @@ def bulk_need():
         Grocery.query.filter(
             Grocery.profile_id == profile,
             Grocery.id.in_(ids),
-        ).update({"status": "Need"}, synchronize_session=False)
+        ).update({"status": "Have"}, synchronize_session=False)
         try:
             db.session.commit()
-            flash(f"{len(ids)} item(s) marked as Need.", "success")
+            flash(f"{len(ids)} item(s) marked as Have.", "success")
         except Exception:
             db.session.rollback()
             flash("Something went wrong.", "error")

--- a/app/models.py
+++ b/app/models.py
@@ -19,7 +19,7 @@ class Grocery(db.Model):
     category = db.Column(db.String(100), nullable=True)   # e.g. "Produce", "Dairy", "Meat"
 
     status = db.Column(
-        db.Enum("Need", "Have", "Out", name="grocerystatus"),
+        db.Enum("Need", "Have", name="grocerystatus"),
         nullable=False,
         default="Need",
     )

--- a/app/seeds.py
+++ b/app/seeds.py
@@ -34,7 +34,7 @@ def do_seed(profiles):
             ("Salmon Fillet",   1.0,  "lbs",     "Seafood",   "Need"),
             ("Spinach",         5.0,  "oz",      "Produce",   "Need"),
             ("Oats",            1.0,  "bag",     "Pantry",    "Have"),
-            ("Bananas",         1.0,  "bunch",   "Produce",   "Out"),
+            ("Bananas",         1.0,  "bunch",   "Produce",   "Need"),
         ]
         G = {}  # name → Grocery instance
         for name, qty, unit, cat, status in grocery_rows:

--- a/app/templates/groceries/add.html
+++ b/app/templates/groceries/add.html
@@ -50,9 +50,8 @@
       <select id="status" name="status"
               class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100
                      focus:outline-none focus:border-indigo-500 transition-colors">
-        <option value="Need" selected>Need</option>
-        <option value="Have">Have</option>
-        <option value="Out">Out</option>
+        <option value="Need" selected>Need (add to shopping list)</option>
+        <option value="Have">Have (already in stock)</option>
       </select>
     </div>
 

--- a/app/templates/groceries/edit.html
+++ b/app/templates/groceries/edit.html
@@ -51,7 +51,7 @@
       <select id="status" name="status"
               class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm text-gray-100
                      focus:outline-none focus:border-indigo-500 transition-colors">
-        {% for s in ["Need", "Have", "Out"] %}
+        {% for s in ["Need", "Have"] %}
         <option value="{{ s }}" {{ 'selected' if item.status == s else '' }}>{{ s }}</option>
         {% endfor %}
       </select>

--- a/app/templates/groceries/index.html
+++ b/app/templates/groceries/index.html
@@ -10,52 +10,55 @@
   </a>
 </div>
 
-<!-- Filter bar -->
+<!-- View tabs -->
 <div class="flex gap-2 mb-6">
-  <a href="{{ url_for('groceries.index') }}"
+  <a href="{{ url_for('groceries.index', status='Need') }}"
      class="px-3 py-1.5 rounded text-sm transition-colors
-            {{ 'bg-indigo-700 text-white' if not status_filter else 'bg-gray-800 text-gray-400 hover:text-white' }}">
+            {{ 'bg-indigo-700 text-white' if status_filter == 'Need' and not show_all else 'bg-gray-800 text-gray-400 hover:text-white' }}">
+    Shopping List
+  </a>
+  <a href="{{ url_for('groceries.index', status='Have') }}"
+     class="px-3 py-1.5 rounded text-sm transition-colors
+            {{ 'bg-indigo-700 text-white' if status_filter == 'Have' and not show_all else 'bg-gray-800 text-gray-400 hover:text-white' }}">
+    Have
+  </a>
+  <a href="{{ url_for('groceries.index', status='all') }}"
+     class="px-3 py-1.5 rounded text-sm transition-colors
+            {{ 'bg-indigo-700 text-white' if show_all else 'bg-gray-800 text-gray-400 hover:text-white' }}">
     All
   </a>
-  {% for label in ["Need", "Have", "Out"] %}
-  <a href="{{ url_for('groceries.index', status=label) }}"
-     class="px-3 py-1.5 rounded text-sm transition-colors
-            {{ 'bg-indigo-700 text-white' if status_filter == label else 'bg-gray-800 text-gray-400 hover:text-white' }}">
-    {{ label }}
-  </a>
-  {% endfor %}
 </div>
 
 {% if groceries %}
 
-<!-- Bulk "Mark as Need" form — checkboxes use form="bulk-form" to associate without nesting -->
-<form id="bulk-form" method="post" action="{{ url_for('groceries.bulk_need') }}"></form>
-
+{% if status_filter == "Need" and not show_all %}
+<!-- Bulk checkout — checkboxes use form="bulk-form" to stay out of nested forms -->
+<form id="bulk-form" method="post" action="{{ url_for('groceries.bulk_have') }}"></form>
 <div class="flex items-center gap-3 mb-3">
   <button type="submit" form="bulk-form"
-          class="px-3 py-1.5 bg-green-800 hover:bg-green-700 rounded text-sm text-green-200 transition-colors">
-    Mark Selected as Need
+          class="px-3 py-1.5 bg-blue-800 hover:bg-blue-700 rounded text-sm text-blue-200 transition-colors">
+    ✓ Got Selected
   </button>
   <label class="flex items-center gap-2 text-sm text-gray-400 cursor-pointer select-none">
     <input type="checkbox" id="select-all" class="rounded accent-indigo-500"> Select all
   </label>
 </div>
+{% endif %}
 
 <div class="flex flex-col gap-2">
   {% for item in groceries %}
   <div class="bg-gray-900 rounded-lg flex items-center gap-3 px-4 py-3">
 
-    <!-- Checkbox associated with the bulk-form above -->
+    {% if status_filter == "Need" and not show_all %}
     <input type="checkbox" name="item_ids" value="{{ item.id }}" form="bulk-form"
            class="bulk-check rounded accent-indigo-500 shrink-0">
+    {% endif %}
 
-    <!-- Status badge: green=Need, blue=Have, gray=Out -->
+    <!-- Status badge: green=Need (on list), blue=Have -->
     {% if item.status == "Need" %}
-      <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-green-900 text-green-300">Need</span>
-    {% elif item.status == "Have" %}
-      <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-blue-900 text-blue-300">Have</span>
+      <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-green-900 text-green-300">On List</span>
     {% else %}
-      <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-gray-700 text-gray-400">Out</span>
+      <span class="shrink-0 text-xs px-2 py-0.5 rounded-full bg-blue-900 text-blue-300">Have</span>
     {% endif %}
 
     <div class="flex-1 min-w-0">
@@ -71,6 +74,21 @@
     <span class="shrink-0 text-xs px-2 py-0.5 rounded bg-gray-700 text-gray-400">
       {{ item.category }}
     </span>
+    {% endif %}
+
+    <!-- Quick status actions -->
+    {% if item.status == "Need" %}
+    <form method="post" action="{{ url_for('groceries.got_it', item_id=item.id) }}">
+      <button class="shrink-0 text-xs px-3 py-1.5 rounded bg-blue-900 hover:bg-blue-800 text-blue-200 transition-colors">
+        ✓ Got It
+      </button>
+    </form>
+    {% else %}
+    <form method="post" action="{{ url_for('groceries.out_of_stock', item_id=item.id) }}">
+      <button class="shrink-0 text-xs px-3 py-1.5 rounded bg-gray-700 hover:bg-gray-600 text-gray-300 transition-colors">
+        Out of Stock
+      </button>
+    </form>
     {% endif %}
 
     <a href="{{ url_for('groceries.edit', item_id=item.id) }}"
@@ -90,11 +108,14 @@
 
 {% else %}
 <p class="text-gray-500">
-  {% if status_filter %}
-    No {{ status_filter | lower }} items.
-    <a href="{{ url_for('groceries.index') }}" class="text-indigo-400 hover:underline">Show all.</a>
-  {% else %}
+  {% if status_filter == "Have" %}
+    Nothing in the pantry yet.
+    <a href="{{ url_for('groceries.index') }}" class="text-indigo-400 hover:underline">View shopping list.</a>
+  {% elif show_all %}
     No groceries yet. <a href="{{ url_for('groceries.add') }}" class="text-indigo-400 hover:underline">Add one.</a>
+  {% else %}
+    Shopping list is empty.
+    <a href="{{ url_for('groceries.add') }}" class="text-indigo-400 hover:underline">Add an item.</a>
   {% endif %}
 </p>
 {% endif %}
@@ -103,10 +124,13 @@
 {% block scripts %}
 {{ super() }}
 <script>
-document.getElementById('select-all').addEventListener('change', function () {
-  document.querySelectorAll('.bulk-check').forEach(function (cb) {
-    cb.checked = this.checked;
-  }, this);
-});
+var selectAll = document.getElementById('select-all');
+if (selectAll) {
+  selectAll.addEventListener('change', function () {
+    document.querySelectorAll('.bulk-check').forEach(function (cb) {
+      cb.checked = this.checked;
+    }, this);
+  });
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
## Summary

- Removes the `Out` status — items are now either **Need** (on the shopping list) or **Have** (in stock)
- Groceries page now defaults to the **Shopping List** view instead of showing all items
- Each item on the list gets a **✓ Got It** button; Have items get an **Out of Stock** button to add them back
- Bulk **✓ Got Selected** button on the shopping list for checkout
- View tabs: **Shopping List** | **Have** | **All**

## Notes

- `flask db-reset --yes` required since the `groceries` Enum changed (drops `Out` value)
- MySQL users will need a migration; SQLite users just reset

## Test plan

- [ ] Default page load shows Shopping List (Need items only)
- [ ] "✓ Got It" moves an item to Have
- [ ] "Out of Stock" moves a Have item back to the shopping list
- [ ] "✓ Got Selected" bulk-marks checked items as Have
- [ ] Adding a new item defaults to Need
- [ ] All / Have tabs show correct items
- [ ] `flask db-reset --yes` recreates DB cleanly with no Out items

🤖 Generated with [Claude Code](https://claude.com/claude-code)