### PR TITLE
Cache recipe macros in DB columns at write time

### DIFF
--- a/app/blueprints/recipes.py
+++ b/app/blueprints/recipes.py
@@ -49,7 +49,6 @@ def view(recipe_id):
     log_count = len(entries)
     log_sum = None
     if log_count:
-        # TODO make this fetch from recipe entry in db once macro columns are added
         log_sum = {
             "calories":  round(sum(e.calories  or 0 for e in entries), 1),
             "protein_g": round(sum(e.protein_g or 0 for e in entries), 1),
@@ -94,6 +93,8 @@ def add():
         db.session.flush()  # get recipe.id before adding ingredients
 
         _save_ingredients(recipe.id, profile)
+        db.session.flush()  # make ingredients visible to cache_macros
+        recipe.cache_macros()
 
         try:
             db.session.commit()
@@ -144,6 +145,8 @@ def edit(recipe_id):
         # Replace all ingredients with the submitted set
         RecipeIngredient.query.filter_by(recipe_id=recipe.id).delete()
         _save_ingredients(recipe.id, profile)
+        db.session.flush()  # make new ingredients visible to cache_macros
+        recipe.cache_macros()
 
         try:
             db.session.commit()

--- a/app/models.py
+++ b/app/models.py
@@ -82,6 +82,32 @@ class Recipe(db.Model):
         default="Active",
     )
 
+    # Cached macro totals — computed at write time from ingredients × grocery per-unit macros.
+    # Populated on every recipe create/edit (including ingredient changes); None when no
+    # ingredients are linked or macro data is unavailable for all ingredients.
+    #
+    # Migration SQL for existing databases (run once against a live DB):
+    #
+    #   -- MySQL / MariaDB:
+    #   ALTER TABLE recipes
+    #     ADD COLUMN cached_calories  FLOAT         NULL,
+    #     ADD COLUMN cached_protein_g FLOAT         NULL,
+    #     ADD COLUMN cached_carbs_g   FLOAT         NULL,
+    #     ADD COLUMN cached_fat_g     FLOAT         NULL,
+    #     ADD COLUMN macros_complete  TINYINT(1)    NULL;
+    #
+    #   -- SQLite (one statement per column):
+    #   ALTER TABLE recipes ADD COLUMN cached_calories  REAL;
+    #   ALTER TABLE recipes ADD COLUMN cached_protein_g REAL;
+    #   ALTER TABLE recipes ADD COLUMN cached_carbs_g   REAL;
+    #   ALTER TABLE recipes ADD COLUMN cached_fat_g     REAL;
+    #   ALTER TABLE recipes ADD COLUMN macros_complete  INTEGER;
+    cached_calories  = db.Column(db.Float,   nullable=True)
+    cached_protein_g = db.Column(db.Float,   nullable=True)
+    cached_carbs_g   = db.Column(db.Float,   nullable=True)
+    cached_fat_g     = db.Column(db.Float,   nullable=True)
+    macros_complete  = db.Column(db.Boolean, nullable=True)
+
     created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
     updated_at = db.Column(
         db.DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow
@@ -98,6 +124,9 @@ class Recipe(db.Model):
 
         Returns a dict with cal/protein/carbs/fat totals and a 'complete' flag
         that is False when any linked grocery is missing macro data.
+
+        This property is used only on the write path (create/edit) to populate the
+        cached_* columns.  Read paths should use the stored columns directly.
         """
         cal = protein = carbs = fat = 0.0
         complete = True
@@ -118,6 +147,27 @@ class Recipe(db.Model):
             "fat_g":     round(fat,     1),
             "complete":  complete,
         }
+
+    def cache_macros(self):
+        """Compute macros and persist results into the cached_* columns.
+
+        If the recipe has no ingredients, all cached columns are set to None.
+        Call this after any ingredient create/update/delete and before db.session.commit().
+        """
+        if not self.ingredients:
+            self.cached_calories  = None
+            self.cached_protein_g = None
+            self.cached_carbs_g   = None
+            self.cached_fat_g     = None
+            self.macros_complete  = None
+            return
+
+        result = self.computed_macros
+        self.cached_calories  = result["calories"]
+        self.cached_protein_g = result["protein_g"]
+        self.cached_carbs_g   = result["carbs_g"]
+        self.cached_fat_g     = result["fat_g"]
+        self.macros_complete  = result["complete"]
 
     def __repr__(self):
         return f"<Recipe profile={self.profile_id!r} name={self.name!r}>"

--- a/app/templates/macros/add.html
+++ b/app/templates/macros/add.html
@@ -53,7 +53,11 @@
                        focus:outline-none focus:border-indigo-500 transition-colors">
           <option value="">— select a recipe —</option>
           {% for r in recipes %}
-          <option value="{{ r.id }}">{{ r.name }}</option>
+          <option value="{{ r.id }}"
+                  data-calories="{{ r.cached_calories if r.cached_calories is not none else '' }}"
+                  data-protein="{{ r.cached_protein_g if r.cached_protein_g is not none else '' }}"
+                  data-carbs="{{ r.cached_carbs_g if r.cached_carbs_g is not none else '' }}"
+                  data-fat="{{ r.cached_fat_g if r.cached_fat_g is not none else '' }}">{{ r.name }}</option>
           {% endfor %}
         </select>
       </div>
@@ -133,6 +137,19 @@ radios.forEach(function (r) {
       document.getElementById('recipe_id').value = '';
     }
   });
+});
+
+// Auto-fill macro fields from cached recipe macros when a recipe is selected.
+document.getElementById('recipe_id').addEventListener('change', function () {
+  var opt = this.options[this.selectedIndex];
+  var cal     = opt.getAttribute('data-calories');
+  var protein = opt.getAttribute('data-protein');
+  var carbs   = opt.getAttribute('data-carbs');
+  var fat     = opt.getAttribute('data-fat');
+  document.getElementById('calories').value  = cal     || '';
+  document.getElementById('protein_g').value = protein || '';
+  document.getElementById('carbs_g').value   = carbs   || '';
+  document.getElementById('fat_g').value     = fat     || '';
 });
 </script>
 {% endblock %}

--- a/app/templates/recipes/index.html
+++ b/app/templates/recipes/index.html
@@ -66,6 +66,17 @@
           <span>{{ recipe.ingredients | length }} ingredient{{ 's' if recipe.ingredients | length != 1 }}</span>
           {% endif %}
         </div>
+        {% if recipe.cached_calories is not none %}
+        <div class="flex gap-3 mt-1.5 text-xs">
+          <span class="text-yellow-500">{{ recipe.cached_calories }} kcal</span>
+          <span class="text-blue-400">P {{ recipe.cached_protein_g }}g</span>
+          <span class="text-green-400">C {{ recipe.cached_carbs_g }}g</span>
+          <span class="text-orange-400">F {{ recipe.cached_fat_g }}g</span>
+          {% if not recipe.macros_complete %}
+          <span class="text-gray-600">(partial)</span>
+          {% endif %}
+        </div>
+        {% endif %}
       </div>
 
       <div class="flex gap-2 shrink-0">

--- a/app/templates/recipes/view.html
+++ b/app/templates/recipes/view.html
@@ -69,11 +69,40 @@
   </div>
   {% endif %}
 
+  <!-- Cached recipe macros (computed from ingredients at save time) -->
+  {% if recipe.cached_calories is not none %}
+  <h2 class="text-lg font-semibold text-gray-300 mb-3">Recipe Macros</h2>
+  <div class="bg-gray-900 rounded-lg px-4 py-4 mb-6">
+    <p class="text-xs text-gray-500 mb-3">
+      Total from ingredients
+      {%- if not recipe.macros_complete %} <span class="text-yellow-600">(incomplete — some ingredients missing macro data)</span>{% endif %}
+    </p>
+    <div class="grid grid-cols-4 gap-4">
+      <div class="flex flex-col">
+        <span class="text-lg font-bold text-yellow-400">{{ recipe.cached_calories }}</span>
+        <span class="text-xs text-gray-500">kcal</span>
+      </div>
+      <div class="flex flex-col">
+        <span class="text-lg font-bold text-blue-400">{{ recipe.cached_protein_g }}g</span>
+        <span class="text-xs text-gray-500">protein</span>
+      </div>
+      <div class="flex flex-col">
+        <span class="text-lg font-bold text-green-400">{{ recipe.cached_carbs_g }}g</span>
+        <span class="text-xs text-gray-500">carbs</span>
+      </div>
+      <div class="flex flex-col">
+        <span class="text-lg font-bold text-orange-400">{{ recipe.cached_fat_g }}g</span>
+        <span class="text-xs text-gray-500">fat</span>
+      </div>
+    </div>
+  </div>
+  {% endif %}
+
   <!-- Macro log stats (from logged entries) -->
   {% if log_count %}
   <h2 class="text-lg font-semibold text-gray-300 mb-3">Macro Log Stats</h2>
   <div class="bg-gray-900 rounded-lg px-4 py-4 mb-6">
-    <p class="text-xs text-gray-500 mb-3">Sum of macros per serving:</p>
+    <p class="text-xs text-gray-500 mb-3">Sum across {{ log_count }} log {{ 'entry' if log_count == 1 else 'entries' }}:</p>
     <div class="grid grid-cols-4 gap-4">
       <div class="flex flex-col">
         <span class="text-lg font-bold text-yellow-400">{{ log_sum.calories }}</span>


### PR DESCRIPTION
## Summary

- Added five new nullable columns to `Recipe`: `cached_calories`, `cached_protein_g`, `cached_carbs_g`, `cached_fat_g` (all `Float`), and `macros_complete` (`Boolean`)
- Added `Recipe.cache_macros()` method that calls the existing `computed_macros` property and writes results into those columns; sets all to `None` when the recipe has no ingredients
- `cache_macros()` is called on every create and edit in `recipes.py`, with a `db.session.flush()` between ingredient insertion and the macro calculation so the ORM sees the latest ingredient rows
- Updated `computed_macros` docstring to make clear it is now a write-path-only helper
- Removed the TODO comment from the `view` route; `log_sum` still aggregates from `MacroEntry` rows (unchanged behaviour)
- Migration SQL for MySQL and SQLite is embedded as a comment block next to the new model columns

## What changed in templates

- `recipes/index.html`: each recipe card now shows a macro summary line (calories / P / C / F) when cached data is present; marks partial data with `(partial)`
- `recipes/view.html`: new "Recipe Macros" card above the existing "Macro Log Stats" card; displays cached totals with a warning when `macros_complete` is false
- `macros/add.html`: recipe `<option>` elements carry `data-calories/protein/carbs/fat` attributes; a new JS handler auto-fills the macro input fields when the user picks a recipe from the dropdown

## Reviewer / tester focus

- Create a recipe with grocery-linked ingredients that have macro data → confirm `cached_*` columns are populated in DB and show on the list/view pages
- Edit a recipe (change ingredients) → confirm cached values update
- Create a recipe with no ingredients → confirm all cached columns remain `NULL`
- Create a recipe where some grocery items lack macro data → confirm `macros_complete = false` and the "(incomplete)" warning appears on the view page
- On the macro log Add page, switch to "From recipe", pick a recipe with cached data → confirm fields auto-fill

## Migration note

Existing databases need the five columns added manually. SQL is in `app/models.py` next to the column definitions (MySQL multi-column `ALTER TABLE` and SQLite per-column variants).

Closes #10

> 🤖 Posted by Claude (LLM agent) on behalf of @Wylderfan